### PR TITLE
python 3 compatibility: at least be importable

### DIFF
--- a/ramlizer/RamlBody.py
+++ b/ramlizer/RamlBody.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
-from RamlParseable import RamlParseable
-from decorators import *
+from .RamlParseable import RamlParseable
+from .decorators import *
 import json
 import jsonschema
 

--- a/ramlizer/RamlDocumentation.py
+++ b/ramlizer/RamlDocumentation.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
                
-from RamlParseable import RamlParseable
-from decorators import raml_required, raml_simple_parse, raml_optional, raml_tabbed
+from .RamlParseable import RamlParseable
+from .decorators import raml_required, raml_simple_parse, raml_optional, raml_tabbed
 
 class RamlDocument(RamlParseable):
 

--- a/ramlizer/RamlHeader.py
+++ b/ramlizer/RamlHeader.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
-from RamlNamedParameter import RamlNamedParameter
-from decorators import *
+from .RamlNamedParameter import RamlNamedParameter
+from .decorators import *
 
 class RamlHeader(RamlNamedParameter):
     

--- a/ramlizer/RamlMethod.py
+++ b/ramlizer/RamlMethod.py
@@ -1,11 +1,11 @@
 #!/usr/bin/python
 
-from decorators import *
-from RamlParseable import RamlParseable
-from RamlBody import RamlBody
-from RamlizerParseError import RamlizerParseError
-from RamlResponse import RamlResponse
-from RamlHeader import RamlHeader
+from .decorators import *
+from .RamlParseable import RamlParseable
+from .RamlBody import RamlBody
+from .RamlizerParseError import RamlizerParseError
+from .RamlResponse import RamlResponse
+from .RamlHeader import RamlHeader
 
 class RamlMethod(RamlParseable):
 
@@ -19,7 +19,7 @@ class RamlMethod(RamlParseable):
     @raml_optional
     @raml_simple_parse
     def parse_headers(self):
-        self.headers = {x[0] : RamlHeader(x[0], x[1]) for x in self.yaml['headers'].iteritems()}
+        self.headers = {x[0] : RamlHeader(x[0], x[1]) for x in self.yaml['headers'].items()}
     
     @raml_optional
     @raml_simple_parse
@@ -31,11 +31,11 @@ class RamlMethod(RamlParseable):
     
     @raml_optional
     def parse_body(self):
-        self.body = {body_encoding[0] : RamlBody(body_encoding[0], body_encoding[1]) for body_encoding in self.yaml['body'].iteritems()}
+        self.body = {body_encoding[0] : RamlBody(body_encoding[0], body_encoding[1]) for body_encoding in self.yaml['body'].items()}
         
     @raml_optional
     def parse_responses(self):
-        self.response = {response_code[0] : RamlResponse(response_code[0], response_code[1]) for response_code in self.yaml['responses'].iteritems()}
+        self.response = {response_code[0] : RamlResponse(response_code[0], response_code[1]) for response_code in self.yaml['responses'].items()}
             
     @raml_tabbed
     def __str__(self):

--- a/ramlizer/RamlNamedParameter.py
+++ b/ramlizer/RamlNamedParameter.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
-from RamlParseable import RamlParseable
-from decorators import *
+from .RamlParseable import RamlParseable
+from .decorators import *
 
 class RamlNamedParameter(RamlParseable):
 

--- a/ramlizer/RamlResource.py
+++ b/ramlizer/RamlResource.py
@@ -1,8 +1,10 @@
 #!/usr/bin/python
 
-from .decorators import raml_required, raml_optional, raml_tabbed, raml_simple_parse
+from .decorators import raml_optional, raml_tabbed, raml_simple_parse
 from .RamlParseable import RamlParseable
 from .RamlMethod import RamlMethod
+from .RamlURIParameter import RamlURIParameter
+
 
 class RamlResource(RamlParseable):
 

--- a/ramlizer/RamlResource.py
+++ b/ramlizer/RamlResource.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
 
-from decorators import raml_required, raml_optional, raml_tabbed, raml_simple_parse
-from RamlParseable import RamlParseable
-from RamlMethod import RamlMethod
+from .decorators import raml_required, raml_optional, raml_tabbed, raml_simple_parse
+from .RamlParseable import RamlParseable
+from .RamlMethod import RamlMethod
 
 class RamlResource(RamlParseable):
 
@@ -21,11 +21,11 @@ class RamlResource(RamlParseable):
     
     @raml_optional
     def parse_uriParameters(self): 
-        self.uriParameters = {x[0] : RamlURIParameter(x[1]) for x in self.yaml['uriParameters'].iteritems()}
+        self.uriParameters = {x[0] : RamlURIParameter(x[1]) for x in self.yaml['uriParameters'].items()}
         
     @raml_optional
     def parse_baseUriParameters(self):
-        self.baseUriParameters = {x[0] : RamlURIParameter(x[1]) for x in self.yaml['baseUriParameters'].iteritems()}
+        self.baseUriParameters = {x[0] : RamlURIParameter(x[1]) for x in self.yaml['baseUriParameters'].items()}
         
     @raml_optional
     def parse_get(self):

--- a/ramlizer/RamlResponse.py
+++ b/ramlizer/RamlResponse.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
 
-from decorators import *
-from RamlBody import RamlBody
-from RamlParseable import RamlParseable
+from .decorators import *
+from .RamlBody import RamlBody
+from .RamlParseable import RamlParseable
 
 class RamlResponse(RamlParseable):
 
@@ -20,7 +20,7 @@ class RamlResponse(RamlParseable):
         
     @raml_optional
     def parse_body(self):
-        self.body = {body_encoding[0] : RamlBody(body_encoding[0], body_encoding[1]) for body_encoding in self.yaml['body'].iteritems()}
+        self.body = {body_encoding[0] : RamlBody(body_encoding[0], body_encoding[1]) for body_encoding in self.yaml['body'].items()}
 
     @raml_tabbed        
     def __str__(self):

--- a/ramlizer/RamlRoot.py
+++ b/ramlizer/RamlRoot.py
@@ -1,10 +1,10 @@
 #!/usr/bin/python
 
-from RamlParseable import RamlParseable
-from RamlDocumentation import RamlDocumentation
-from RamlResource import RamlResource
-from RamlURIParameter import RamlURIParameter
-from decorators import raml_required, raml_simple_parse, raml_optional, raml_tabbed
+from .RamlParseable import RamlParseable
+from .RamlDocumentation import RamlDocumentation
+from .RamlResource import RamlResource
+from .RamlURIParameter import RamlURIParameter
+from .decorators import raml_required, raml_simple_parse, raml_optional, raml_tabbed
         
 class RamlRoot(RamlParseable):
 
@@ -25,7 +25,7 @@ class RamlRoot(RamlParseable):
            
     @raml_optional
     def parse_baseUriParameters(self):
-        self.baseUriParameters = {x[0] : RamlURIParameter(x[1]) for x in self.yaml['baseUriParameters'].iteritems()}
+        self.baseUriParameters = {x[0] : RamlURIParameter(x[1]) for x in self.yaml['baseUriParameters'].items()}
         
     @raml_optional
     @raml_simple_parse
@@ -41,11 +41,11 @@ class RamlRoot(RamlParseable):
         
     @raml_optional
     def parse_uriParameters(self): 
-        self.uriParameters = {x[0] : RamlURIParameter(x[1]) for x in self.yaml['uriParameters'].iteritems()}
+        self.uriParameters = {x[0] : RamlURIParameter(x[1]) for x in self.yaml['uriParameters'].items()}
         
     @raml_optional
     def parse_resources(self):
-        self.resources = {x[0] : RamlResource(x[0], x[1]) for x in filter(lambda x: x[0].startswith('/'), self.yaml.iteritems())}
+        self.resources = {x[0] : RamlResource(x[0], x[1]) for x in filter(lambda x: x[0].startswith('/'), self.yaml.items())}
         
     @raml_optional
     def parse_documentation(self):

--- a/ramlizer/RamlURIParameter.py
+++ b/ramlizer/RamlURIParameter.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python
 
-from decorators import *
-from RamlParseable import RamlParseable
-from RamlizerParseError import RamlizerParseError
-from RamlNamedParameter import RamlNamedParameter
+from .decorators import *
+from .RamlParseable import RamlParseable
+from .RamlizerParseError import RamlizerParseError
+from .RamlNamedParameter import RamlNamedParameter
                 
 class RamlURIParameter(RamlNamedParameter):
 

--- a/ramlizer/decorators.py
+++ b/ramlizer/decorators.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-from RamlizerParseError import RamlizerParseError
+from .RamlizerParseError import RamlizerParseError
    
 def raml_required(func):
     def check_required(*args, **kwargs):

--- a/ramlizer/ramlizer.py
+++ b/ramlizer/ramlizer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import yaml
-from RamlRoot import RamlRoot
+from .RamlRoot import RamlRoot
 import os.path
 
 class RamlFile():


### PR DESCRIPTION
This makes `ramlizer` just a bit more compatible with Python 3.

What version of the RAML spec does ramlizer conform to?

Is there a test suite for ramlizer?  I'm currently blocked on actually being able to write an interesting RAML document that's known to be good, and was looking for a tool that could validate for me.
